### PR TITLE
add --filter-release to filter out node-style releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ But the comparison isn't quite as strict, generally leading to a shorter list of
 * `--group` or `-g`: Group commits by prefix, this uses the part of the commit summary that is usually used in Node.js core to indicate subsystem for example. Groups are made up of numbers, letters, `,` and `-`, followed by a `:`.
 * `--exclude-label`: Exclude any commits from the list that come from a GitHub pull request with the given label. Multiple `--exclude-label` options may be provided, they will also be split by `,`. e.g. `--exclude-label=semver-major,meta`.
 * `--patch-only`: An alias for `--exclude-label=semver-major,semver-minor`.
+* `--filter-release`: Exclude Node-style release commits from the list. e.g. `Working on v1.0.0` or `2015-10-21 Version 2.0.0`.
 
 ## License
 

--- a/branch-diff.js
+++ b/branch-diff.js
@@ -149,6 +149,14 @@ if (require.main === module) {
     if (err)
       throw err
 
+    if (argv['filter-release']) {
+      list = list.filter((commit) => {
+        return !(/^Working on v?\d{1,2}\.\d{1,3}\.\d{1,3}$/.test(commit.summary)
+              || /^\d{4}-\d{2}-\d{2},? Version \d{1,2}\.\d{1,3}\.\d{1,3} ("[A-Za-z ]+" )?\((Stable|LTS)\)/.test(commit.summary)
+              || /^\d{4}-\d{2}-\d{2},? io.js v\d{1,2}\.\d{1,3}\.\d{1,3} Release/.test(commit.summary))
+      })
+    }
+
     printCommits(list, simple)
   })
 }


### PR DESCRIPTION
Perhaps this isn’t generic enough, but it works for now.

Release commits do not necessarily have PR-URLs we can ignore by github tags, so this is necessary.