### PR TITLE
Add --format option

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,13 @@ But the comparison isn't quite as strict, generally leading to a shorter list of
 
 ### Options
 
-* `--simple` or `-s`: Don't print full markdown output, good for console printing without the additional fluff.
 * `--group` or `-g`: Group commits by prefix, this uses the part of the commit summary that is usually used in Node.js core to indicate subsystem for example. Groups are made up of numbers, letters, `,` and `-`, followed by a `:`.
 * `--exclude-label`: Exclude any commits from the list that come from a GitHub pull request with the given label. Multiple `--exclude-label` options may be provided, they will also be split by `,`. e.g. `--exclude-label=semver-major,meta`.
 * `--patch-only`: An alias for `--exclude-label=semver-major,semver-minor`.
+* `--format`: Dictates what formatting the output will have. Possible options are: `simple`, `sha`. The default is to print markdown-formatted output.
+  - `simple`: Don't print full markdown output, good for console printing without the additional fluff.
+  - `sha`: Print only the 10-character truncated commit shasums. Good for piping though additional tooling, such as `xargs git cherry-pick` for applying commits.
+* `--simple` or `-s`: An alias for `--format=simple`.
 
 ## License
 

--- a/branch-diff.js
+++ b/branch-diff.js
@@ -100,8 +100,12 @@ function diffCollected (options, branchCommits, callback) {
 }
 
 
-function printCommits (list, simple) {
-  list = list.map((commit) => commitToOutput(commit, simple, ghId))
+function printCommits (list, format) {
+  if (format === 'sha') {
+    list = list.map((commit) => `${commit.sha.substr(0, 10)}`)
+  } else {
+    list = list.map((commit) => commitToOutput(commit, format === 'simple', ghId))
+  }
 
   let out = list.join('\n') + '\n'
 
@@ -129,11 +133,15 @@ if (require.main === module) {
   let argv          = require('minimist')(process.argv.slice(2))
     , branch1       = argv._[0]
     , branch2       = argv._[1]
-    , simple        = argv.simple || argv.s
+    , format        = argv.format
     , group         = argv.group || argv.g
     , endRef        = argv['end-ref']
     , excludeLabels = []
     , options
+
+
+  if (argv.simple || argv.s)
+    format = 'simple'
 
   if (argv['patch-only'])
     excludeLabels = [ 'semver-minor', 'semver-major' ]
@@ -143,12 +151,12 @@ if (require.main === module) {
     excludeLabels = excludeLabels.concat(argv['exclude-label'])
   }
 
-  options = { simple, group, excludeLabels, endRef }
+  options = { simple: format === 'simple', group, excludeLabels, endRef }
 
   branchDiff(branch1, branch2, options, (err, list) => {
     if (err)
       throw err
 
-    printCommits(list, simple)
+    printCommits(list, format)
   })
 }


### PR DESCRIPTION
`-s` is now equal to `--format=simple`

See: https://github.com/rvagg/branch-diff/pull/5

Will add docs soon