### PR TITLE
bin: add reverse option

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ But the comparison isn't quite as strict, generally leading to a shorter list of
   - `sha`: Print only the 10-character truncated commit shasums. Good for piping though additional tooling, such as `xargs git cherry-pick` for applying commits.
 * `--simple` or `-s`: An alias for `--format=simple`.
 * `--filter-release`: Exclude Node-style release commits from the list. e.g. `Working on v1.0.0` or `2015-10-21 Version 2.0.0`.
+* `--reverse`: Reverse the results, this is especially useful when piping output to `xargs`
 
 ## License
 

--- a/branch-diff.js
+++ b/branch-diff.js
@@ -105,12 +105,14 @@ function diffCollected (options, branchCommits, callback) {
 }
 
 
-function printCommits (list, format) {
+function printCommits (list, format, reverse) {
   if (format === 'sha') {
     list = list.map((commit) => `${commit.sha.substr(0, 10)}`)
   } else {
     list = list.map((commit) => commitToOutput(commit, format === 'simple', ghId))
   }
+  
+  if (reverse) list = list.reverse();
 
   let out = list.join('\n') + '\n'
 
@@ -139,6 +141,7 @@ if (require.main === module) {
     , branch1       = argv._[0]
     , branch2       = argv._[1]
     , format        = argv.format
+    , reverse       = argv.reverse
     , group         = argv.group || argv.g
     , endRef        = argv['end-ref']
     , excludeLabels = []
@@ -174,6 +177,6 @@ if (require.main === module) {
       })
     }
 
-    printCommits(list, format)
+    printCommits(list, format, reverse)
   })
 }


### PR DESCRIPTION
This commit adds a command line argument --reverse

If the argument is present the list of commits will be printed in
reverse order. This is especially useful when piping the output of
--format=sha to xargs for cherry-picking.